### PR TITLE
Jjrunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ $ jjrunner.py -a '{"GEM_MASTER_BRANCH": "jjrunner", "GEM_SET_DEBUG": "true", "bu
 
 $ jjrunner.py -a '{"GEM_TEST_FOR_JJRUNNER": "true", "GEM_JENKINS_REASON": "Started by timer", "GEM_LAUNCHPAD_REPO": "test4", "GEM_MASTER_BRANCH": "jjrunner", "GEM_SET_DEBUG": "true", "run_dev_tests": "false", "build_for_ubuntu_trusty": "true" }' master_oq-engine
 ```
+
+#### jobs_checker.sh
+This script allow to check ``zdevel_`` and ``master_`` prefixed Jenkins jobs differences and send email if some pair is different.
+
+##### cron configuration
+
+To automate the checks you can use cron with a command line like this:
+```
+1 * * * * export PATH=<jjrunner path>:$PATH && export ADMIN_MAIL="<admins emails list>" && export JJR_USER=<username> && export JJR_PASS=<password> && jobs_checker.sh
+```

--- a/jobs_checker.sh
+++ b/jobs_checker.sh
@@ -37,7 +37,7 @@ for job in $JOBS; do
 done
 
 if [ "$failed" = "true" ]; then
-    cat /tmp/jobs_checker$$.ctx | $MAILCLI -s "jobs_checker detects a difference" nastasi@openquake.org
+    cat /tmp/jobs_checker$$.ctx | $MAILCLI -s "jobs_checker detects a difference" $ADMIN_MAIL
     test -t 1 && echo "Check found differences, a mail is sent."
 else
     test -t 1 && echo "Differences not found, exit silently."

--- a/jobs_checker.sh
+++ b/jobs_checker.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+# set -x
+MAILCLI=mutt
+
+export PATH=$HOME/git/jjrunner:$PATH
+JOBS="oq-engine oq-libs oq-python oq-platform oq-platform2"
+
+BDIR="$HOME/jobs_checker"
+
+if [ ! -d "$BDIR" ]; then
+    mkdir "$BDIR"
+fi
+cd "$BDIR"
+
+touch /tmp/jobs_checker$$.ctx
+failed=false
+for job in $JOBS; do
+    test -t 1 && echo "job $job ..." | tr -d '\n'
+    for pfx in zdevel master; do
+        jobname=${pfx}_${job}
+        rm -rf "${jobname}"
+        jjrunner.py -D "${jobname}"
+    done
+    echo "=== JOB: $job ===" &>>/tmp/jobs_checker$$.ctx
+    echo "--- args ---" &>>/tmp/jobs_checker$$.ctx
+    diff  <(sed 's/=.*//g;s/^#.*//g' "zdevel_${job}/args.sh") <( sed 's/=.*//g;s/^#.*//g' "master_${job}/args.sh") &>>/tmp/jobs_checker$$.ctx || failed=true
+    for i in $(seq 0 100); do
+        comname="com_$(printf "%02d" $i).sh"
+        if [ ! -f "master_${job}/$comname" ]; then
+            break
+        fi
+        echo "--- $comname ---" &>>/tmp/jobs_checker$$.ctx
+        diff -u "zdevel_${job}/$comname" "master_${job}/$comname" &>>/tmp/jobs_checker$$.ctx || failed=true
+    done
+    test -t 1 && echo " done."
+done
+
+if [ "$failed" = "true" ]; then
+    cat /tmp/jobs_checker$$.ctx | $MAILCLI -s "jobs_checker detects a difference" nastasi@openquake.org
+    test -t 1 && echo "Check found differences, a mail is sent."
+else
+    test -t 1 && echo "Differences not found, exit silently."
+fi
+
+rm /tmp/jobs_checker$$.ctx
+
+


### PR DESCRIPTION
Run CI jobs locally using a JSON string to override default parameters.
With the "--dump" flag is used by ``jobs_checker.sh`` script to compare ``zdevel_`` and ``master_`` prefixed jobs on CI.